### PR TITLE
Added build script variants for linux environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+*.jar
+
+out/
+bin/
+modules/
+mods/
+mlib/
+carapp/
+vetapp/
+
+!lib/*.jar
+

--- a/de.rgra.vet_01/compile.sh
+++ b/de.rgra.vet_01/compile.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+rm -Rf out
+
+JAVA9=${JAVA9:-/usr/lib/jvm/java-9-oracle/bin}
+[ ! -d "$JAVA9" ] && echo "Please configure a JAVA9 env variable pointing to a Java9 JDK /bin directory" && exit 1
+
+# Compile
+$JAVA9/javac -cp lib/* -d out -sourcepath src $(find . -name "*.java")
+cp -r -n resources/. out
+
+# Run
+$JAVA9/java -cp lib/*:out de.rgra.vet.VetServicesApplication

--- a/de.rgra.vet_01/src/de/rgra/vet/visit/VisitDao.java
+++ b/de.rgra.vet_01/src/de/rgra/vet/visit/VisitDao.java
@@ -15,7 +15,7 @@ import de.rgra.vet.pet.PetDao;
 
 public class VisitDao {
 
-	private static final List<String> notes = Arrays.asList("Entwurmt", "Geimpft", "Bruch beim Röntgen festgestellt");
+	private static final List<String> notes = Arrays.asList("Entwurmt", "Geimpft", "Bruch beim RÃ¶ntgen festgestellt");
 	private static final List<Visit> visits = createVisits();
 
 	public List<Visit> getVisitsByPetId(int petId) {

--- a/de.rgra.vet_02/compile.sh
+++ b/de.rgra.vet_02/compile.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+rm -Rf out
+rm -Rf modules
+
+JAVA9=${JAVA9:-/usr/lib/jvm/java-9-oracle/bin}
+[ ! -d "$JAVA9" ] && echo "Please configure a JAVA9 env variable pointing to a Java9 JDK /bin directory" && exit 1
+
+# Compile
+$JAVA9/javac -cp lib/* -d out -sourcepath src $(find . -name "*.java")
+cp -r -n resources/. out
+
+# Create Jar
+$JAVA9/jar --create --file de.rgra.vet.jar -C out .
+
+# Extract Libraries
+cd out
+$JAVA9/jar -xf ../lib/commons-lang-2.6.jar 
+cd ..
+
+# Create Fat Jar
+$JAVA9/jar --create --file de.rgra.vet_fat.jar -C out .
+
+# Create module-info
+$JAVA9/jdeps --generate-module-info modules de.rgra.vet_fat.jar
+
+# Run
+$JAVA9/java -cp lib/*:out de.rgra.vet.VetServicesApplication

--- a/de.rgra.vet_02/src/de/rgra/vet/visit/db/VisitDao.java
+++ b/de.rgra.vet_02/src/de/rgra/vet/visit/db/VisitDao.java
@@ -16,7 +16,7 @@ import de.rgra.vet.visit.model.Visit;
 
 public class VisitDao {
 
-	private static final List<String> notes = Arrays.asList("Entwurmt", "Geimpft", "Bruch beim Röntgen festgestellt");
+	private static final List<String> notes = Arrays.asList("Entwurmt", "Geimpft", "Bruch beim RÃ¶ntgen festgestellt");
 	private static final List<Visit> visits = createVisits();
 
 	public List<Visit> getVisitsByPetId(int petId) {

--- a/de.rgra.vet_03/compile.sh
+++ b/de.rgra.vet_03/compile.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+rm -Rf mods
+mkdir mods
+
+JAVA9=${JAVA9:-/usr/lib/jvm/java-9-oracle/bin}
+[ ! -d "$JAVA9" ] && echo "Please configure a JAVA9 env variable pointing to a Java9 JDK /bin directory" && exit 1
+
+MODULE=de.rgra.model_03
+$JAVA9/javac -p $MODULE/mods -d mods/$MODULE $(find . -path "*/$MODULE/*.java")
+cp -r -n $MODULE/resources/. mods/$MODULE
+cp -r -n $MODULE/mods/. mods
+
+for module in "de.rgra.ui_03" "de.rgra.pet_03" "de.rgra.vet.app_03"
+do
+$JAVA9/javac --module-path mods/ -d mods/$module $(find . -path "*/$module/*.java")
+cp -r -n $module/resources/. mods/$module
+done
+
+# Run
+$JAVA9/java -p mods -m de.rgra.vet.app_03/de.rgra.vet.VetServicesApplication

--- a/de.rgra.vet_04/compile.sh
+++ b/de.rgra.vet_04/compile.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+rm -Rf mods
+mkdir mods
+
+JAVA9=${JAVA9:-/usr/lib/jvm/java-9-oracle/bin}
+[ ! -d "$JAVA9" ] && echo "Please configure a JAVA9 env variable pointing to a Java9 JDK /bin directory" && exit 1
+
+MODULE=de.rgra.model_04
+$JAVA9/javac -p $MODULE/mods -d mods/$MODULE $(find . -path "*/$MODULE/*.java")
+cp -r -n $MODULE/resources/. mods/$MODULE
+cp -r -n $MODULE/mods/. mods
+
+for module in "de.rgra.ui_04" "de.rgra.pet_04" "de.rgra.vet.app_04"
+do
+$JAVA9/javac --module-path mods/ -d mods/$module $(find . -path "*/$module/*.java")
+cp -r -n $module/resources/. mods/$module
+done
+
+# Run
+$JAVA9/java -p mods -m de.rgra.vet.app_04/de.rgra.vet.VetServicesApplication

--- a/de.rgra.vet_04/de.rgra.model_04/src/de/rgra/vet/visit/db/VisitDao.java
+++ b/de.rgra.vet_04/de.rgra.model_04/src/de/rgra/vet/visit/db/VisitDao.java
@@ -14,7 +14,7 @@ import de.rgra.vet.visit.model.Visit;
 
 public class VisitDao {
 
-	private static final List<String> notes = Arrays.asList("Entwurmt", "Geimpft", "Bruch beim Röntgen festgestellt");
+	private static final List<String> notes = Arrays.asList("Entwurmt", "Geimpft", "Bruch beim RÃ¶ntgen festgestellt");
 	private static final List<Visit> visits = createVisits();
 
 	public List<Visit> getVisitsByPetId(int petId) {

--- a/de.rgra.vet_05/compile.sh
+++ b/de.rgra.vet_05/compile.sh
@@ -1,0 +1,68 @@
+#!/bin/bash -e
+rm -Rf mods
+rm -Rf mlib
+mkdir mlib
+mkdir mlib/vet
+mkdir mlib/car
+mkdir mods
+
+JAVA9=${JAVA9:-/usr/lib/jvm/java-9-oracle/bin}
+[ ! -d "$JAVA9" ] && echo "Please configure a JAVA9 env variable pointing to a Java9 JDK /bin directory" && exit 1
+
+MODULE=de.rgra.model_05
+SOURCES=$(find . -path "*/$MODULE/*.java")
+$JAVA9/javac -p $MODULE/mods -d mods/vet/$MODULE $SOURCES
+$JAVA9/javac -p $MODULE/mods -d mods/car/$MODULE $SOURCES
+cp -r -n $MODULE/resources/. mods/vet/$MODULE
+cp -r -n $MODULE/resources/. mods/car/$MODULE
+cp -r -n $MODULE/mods/. mods/vet
+cp -r -n $MODULE/mods/. mods/car
+cp -r -n $MODULE/mods/. mlib/vet
+cp -r -n $MODULE/mods/. mlib/car
+$JAVA9/jar --create --file mlib/vet/de.rgra.model.jar -C mods/vet/$MODULE .
+$JAVA9/jar --create --file mlib/car/de.rgra.model.jar -C mods/car/$MODULE .
+
+
+MODULE=de.rgra.ui_05
+SOURCES=$(find . -path "*/$MODULE/*.java")
+$JAVA9/javac -p mods/vet -d mods/vet/$MODULE $SOURCES
+cp -r -n $MODULE/resources/. mods/vet/$MODULE
+$JAVA9/javac -p mods/car -d mods/car/$MODULE $SOURCES
+cp -r -n $MODULE/resources/. mods/car/$MODULE
+$JAVA9/jar --create --file=mlib/vet/de.rgra.ui.jar -C mods/vet/$MODULE .
+$JAVA9/jar --create --file=mlib/car/de.rgra.ui.jar -C mods/car/$MODULE .
+
+MODULE=de.rgra.car_05
+SOURCES=$(find . -path "*/$MODULE/*.java")
+$JAVA9/javac -p mods/car -d mods/car/$MODULE $SOURCES
+cp -r -n $MODULE/resources/. mods/car/$MODULE
+$JAVA9/jar --create --file=mlib/car/de.rgra.car.jar -C mods/car/$MODULE .
+
+MODULE=de.rgra.pet_05
+SOURCES=$(find . -path "*/$MODULE/*.java")
+$JAVA9/javac -p mods/vet -d mods/vet/$MODULE $SOURCES
+cp -r -n $MODULE/resources/. mods/vet/$MODULE
+$JAVA9/jar --create --file=mlib/vet/de.rgra.pet.jar -C mods/vet/$MODULE .
+
+
+MODULE=de.rgra.app_05
+SOURCES=$(find . -path "*/$MODULE/*.java")
+$JAVA9/javac -p mods/vet -d mods/vet/$MODULE $SOURCES
+cp -r -n $MODULE/resources/. mods/vet/$MODULE
+$JAVA9/javac -p mods/car -d mods/car/$MODULE $SOURCES
+cp -r -n $MODULE/resources/. mods/car/$MODULE
+$JAVA9/jar --create --file=mlib/vet/de.rgra.app.jar -C mods/vet/$MODULE .
+$JAVA9/jar --create --file=mlib/car/de.rgra.app.jar -C mods/car/$MODULE .
+
+
+MODULE=de.rgra.car.app_05
+SOURCES=$(find . -path "*/$MODULE/*.java")
+$JAVA9/javac -p mods/car -d mods/car/$MODULE $SOURCES
+cp -r -n $MODULE/resources/. mods/car/$MODULE
+$JAVA9/jar --create --file=mlib/car/de.rgra.car.app.jar -C mods/car/$MODULE .
+
+MODULE=de.rgra.vet.app_05
+SOURCES=$(find . -path "*/$MODULE/*.java")
+$JAVA9/javac -p mods/vet -d mods/vet/$MODULE $SOURCES
+cp -r -n $MODULE/resources/. mods/vet/$MODULE
+$JAVA9/jar --create --file=mlib/vet/de.rgra.vet.app.jar -C mods/vet/$MODULE .

--- a/de.rgra.vet_05/link.sh
+++ b/de.rgra.vet_05/link.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+rm -Rf vetapp
+rm -Rf carapp
+rm -Rf out
+
+JAVA9=${JAVA9:-/usr/lib/jvm/java-9-oracle/bin}
+[ ! -d "$JAVA9" ] && echo "Please configure a JAVA9 env variable pointing to a Java9 JDK /bin directory" && exit 1
+
+# Create module-info
+# $JAVA9/jdeps --generate-module-info modules mlib/vet/commons-lang-2.6.jar
+# exports .enum not allowed.
+
+# Patch commons-lang with module info, because only named modules are allowed for jlink
+mkdir out
+cd out
+$JAVA9/jar -xf ../mlib/vet/commons-lang-2.6.jar
+cd ..
+$JAVA9/javac -cp mlib/vet/commons-lang-2.6.jar -d out modules/commons.lang/module-info.java
+$JAVA9/jar uf mlib/vet/commons-lang-2.6.jar -C out module-info.class
+$JAVA9/jar uf mlib/car/commons-lang-2.6.jar -C out module-info.class
+
+$JAVA9/jlink --module-path "$JAVA9/../jmods":mlib/vet --add-modules de.rgra.vet.app_05 --output vetapp --launcher vet=de.rgra.vet.app_05/de.rgra.vet.VetAppConfiguration --limit-modules de.rgra.app_05,de.rgra.model_05,de.rgra.pet_05,de.rgra.ui_05,commons.lang,java.base,javafx.base,javafx.controls,javafx.graphics --compress 2 --strip-debug  --no-header-files --no-man-pages
+$JAVA9/jlink --module-path "$JAVA9/../jmods":mlib/car --add-modules de.rgra.car.app_05 --output carapp --launcher car=de.rgra.car.app_05/de.rgra.car.app.CarAppConfiguration  --compress 2 --strip-debug  --no-header-files --no-man-pages
+vetapp/bin/vet
+

--- a/de.rgra.vet_05/run.sh
+++ b/de.rgra.vet_05/run.sh
@@ -1,0 +1,6 @@
+JAVA9=${JAVA9:-/usr/lib/jvm/java-9-oracle/bin}
+[ ! -d "$JAVA9" ] && echo "Please configure a JAVA9 env variable pointing to a Java9 JDK /bin directory" && exit 1
+
+$JAVA9/java -p mods/car -m de.rgra.car.app_05/de.rgra.car.app.CarAppConfiguration
+# $JAVA9/java -p mods/vet -m de.rgra.vet.app_05/de.rgra.vet.VetAppConfiguration
+


### PR DESCRIPTION
This is a great example to ease migrating to Java 9 - well done! 

Added shell scripts that work in linux environments.
Fixed encoding of ö-umlaut in VisitDao.java.